### PR TITLE
Subtly display ¶ beside methods, auto-expand hashed urls

### DIFF
--- a/cbv/static/permalinks.js
+++ b/cbv/static/permalinks.js
@@ -43,7 +43,12 @@
         $('.accordion-group').on('click', '.permalink', function(evt){
             evt.preventDefault();
             evt.stopImmediatePropagation();
-            window.location = $(this).attr('href');
+            if(history.pushState){
+                history.pushState({}, doc.title || '', $(this).attr('href'));
+            }
+            else {
+                window.location = $(this).attr('href');
+            }
         });
     })
 })(document);

--- a/cbv/static/permalinks.js
+++ b/cbv/static/permalinks.js
@@ -1,0 +1,17 @@
+// Auto-expand accordian if url contains a valid hash
+(function(doc){
+    "use strict";
+
+    var DOMReady = function(a){
+        var b = doc, c = 'addEventListener';
+        b[c] ? b[c]('DOMContentLoaded', a): window.attachEvent('onload', a);
+    };
+
+    DOMReady(function() {
+        var section, hash = window.location.hash;
+        if(hash){
+            section = doc.querySelector(hash);
+            section.parentNode.querySelector('h3').click();
+        }
+    });
+})(document);

--- a/cbv/static/permalinks.js
+++ b/cbv/static/permalinks.js
@@ -2,18 +2,48 @@
 (function(doc){
     "use strict";
 
+    // On DOM Load...
     $(function(){
-        var $section, hash = window.location.hash;
+        var hash = window.location.hash;
+        var headerHeight = $('.navbar').height();
+        var methods = $('.accordion-group .accordion-heading');
+        var methodCount = methods.length;
+
+        // Sets-up an event handler that will expand and scroll to the desired
+        // (hash) method.
         if(hash){
-            $section = $(hash);
-            if($section){
-                $(doc).one('hidden.bs.collapse', hash, function(){
-                    $section.parent().find('h3').click();
-                });
-                $('html, body').animate({
-                        scrollTop: $(hash).offset().top
-                }, 500);
-            }
+            // We need to know that all the panes have (at least initially)
+            // collapsed as a result of loading the page. Unfortunately, we
+            // only get events for each collapsed item, so we count...
+            $(doc).on('hidden.bs.collapse', function(evt) {
+                var methodTop, $hdr = $(hash).parent('.accordion-group');
+                methodCount--;
+                if(methodCount === 0){
+                    // OK, they've /all/ collapsed, now we expand the one we're
+                    // interested in the scroll to it.
+
+                    // First, remove this very event handler
+                    $(doc).off('hidden.bs.collapse');
+                    // Now wait just a beat more to allow the last collapse
+                    // animation to complete...
+                    setTimeout(function(){
+                        // Open the desired method
+                        $hdr.find('h3').click();
+                        // Take into account the fixed header and the margin
+                        methodTop = $hdr.offset().top - headerHeight - 8;
+                        // Scroll it into view
+                        $('html, body').animate({scrollTop: methodTop}, 250);
+                    }, 250);
+                }
+            });
         }
+
+        // Delegated event handler to prevent the collapse/expand function of
+        // a method's header when clicking the Pilcrow (permalink)
+        $('.accordion-group').on('click', '.permalink', function(evt){
+            evt.preventDefault();
+            evt.stopImmediatePropagation();
+            window.location = $(this).attr('href');
+        });
     })
 })(document);

--- a/cbv/static/permalinks.js
+++ b/cbv/static/permalinks.js
@@ -1,17 +1,19 @@
-// Auto-expand accordian if url contains a valid hash
+// Auto-expand the accordion and jump to the target if url contains a valid hash
 (function(doc){
     "use strict";
 
-    var DOMReady = function(a){
-        var b = doc, c = 'addEventListener';
-        b[c] ? b[c]('DOMContentLoaded', a): window.attachEvent('onload', a);
-    };
-
-    DOMReady(function() {
-        var section, hash = window.location.hash;
+    $(function(){
+        var $section, hash = window.location.hash;
         if(hash){
-            section = doc.querySelector(hash);
-            section.parentNode.querySelector('h3').click();
+            $section = $(hash);
+            if($section){
+                $(doc).one('hidden.bs.collapse', hash, function(){
+                    $section.parent().find('h3').click();
+                });
+                $('html, body').animate({
+                        scrollTop: $(hash).offset().top
+                }, 500);
+            }
         }
-    });
+    })
 })(document);

--- a/cbv/static/style.css
+++ b/cbv/static/style.css
@@ -88,6 +88,14 @@ code.attribute.overridden {
 .method.accordion-group header small {
     padding-top: 3px;
 }
+.method.accordion-group .permalink {
+    opacity: 0.0;
+    font-size: 0.75em;
+    transition: opacity 0.5s;
+}
+.method.accordion-group:hover .permalink {
+    opacity: 1.0;
+}
 .namesake.accordion-group {
     margin-top: 10px;
 }

--- a/cbv/templates/cbv/klass_detail.html
+++ b/cbv/templates/cbv/klass_detail.html
@@ -23,6 +23,7 @@
         })
     </script>
     <script src="{% static 'ccbv.js' %}"></script>
+    <script src="{% static 'permalinks.js' %}"></script>
 {% endblock %}
 
 
@@ -144,6 +145,7 @@
                                     {% if namesakes|length == 1 %}
                                         <small class="pull-right">{{ method.klass }}</small>
                                     {% endif %}
+                                    <a class="permalink" href="{{ klass.get_absolute_url }}#{{ method.name }}">&para;</a>
                                 </h3>
                             </header>
                             <div id="{{ method.name }}" class="accordion-body collapse in">


### PR DESCRIPTION
Subtly adds 'pilcrow' symbol "¶" beside method names as an anchor to the permalink for this method. Also, if the URL contains a hash, and it references a section, automatically jump to that section and expand that section on the page.

Should address #37.