### PR TITLE
Remove regex cludge for docs version checking

### DIFF
--- a/cbv/management/commands/fetch_docs_urls.py
+++ b/cbv/management/commands/fetch_docs_urls.py
@@ -15,8 +15,7 @@ class Command(BaseCommand):
     django_doc_url = 'https://docs.djangoproject.com/en/{version}'
     # Django no longer hosts docs for < 1.7, so we only want versions that
     # are both in CCBV and at least as recent as 1.7
-    exclude_regex = r'^1\.[3-6]'
-    django_versions = ProjectVersion.objects.exclude(version_number__regex=exclude_regex).values_list('version_number',
+    django_versions = ProjectVersion.objects.exclude(sortable_version_number__lt='0107').values_list('version_number',
         flat=True)
     # Django has custom inventory file name
     inv_filename = '_objects'


### PR DESCRIPTION
Now we have denormed sortable version numbers, we can use those. Saves
us getting in a mess when discontinued docs versions start reaching
2.x, at least.