### PR TITLE
Add canonical tags for latest django version

### DIFF
--- a/cbv/models.py
+++ b/cbv/models.py
@@ -87,6 +87,7 @@ class ModuleManager(models.Manager):
                 version_number=version_number)
             )
 
+
 class Module(models.Model):
     """ Represents a module of a python project """
 
@@ -132,6 +133,12 @@ class Module(models.Model):
             'version': self.project_version.version_number,
             'module': self.name,
         })
+
+    def get_latest_version_url(self):
+        latest = self._meta.model.objects.filter(
+            project_version__project=self.project_version.project,
+            name=self.name).order_by('-project_version__sortable_version_number').first()
+        return latest.get_absolute_url()
 
 
 class KlassManager(models.Manager):
@@ -200,6 +207,13 @@ class Klass(models.Model):
             'module': self.module.name,
             'klass': self.name
         })
+
+    def get_latest_version_url(self):
+        latest = self._meta.model.objects.filter(
+            module__project_version__project=self.module.project_version.project,
+            module__name=self.module.name,
+            name=self.name).order_by('-module__project_version__sortable_version_number').first()
+        return latest.get_absolute_url()
 
     def get_source_url(self):
         url = 'https://github.com/django/django/blob/'

--- a/cbv/templates/cbv/klass_detail.html
+++ b/cbv/templates/cbv/klass_detail.html
@@ -8,7 +8,7 @@
 {% block title %}{{ object }}{% endblock %}
 
 {% block extraheaders %}
-    <link rel="canonical" href="{{ request.scheme }}://{{ request.get_host }}{% url 'klass-detail' package=view.kwargs.package version=latest_project_version module=view.kwargs.module klass=view.kwargs.klass %}">
+    <link rel="canonical" href="{{ request.scheme }}://{{ request.get_host }}{{ object.get_latest_version_url }}">
 {% endblock %}
 
 

--- a/cbv/templates/cbv/klass_detail.html
+++ b/cbv/templates/cbv/klass_detail.html
@@ -7,6 +7,10 @@
 
 {% block title %}{{ object }}{% endblock %}
 
+{% block extraheaders %}
+    <link rel="canonical" href="{{ request.scheme }}://{{ request.get_host }}{% url 'klass-detail' package=view.kwargs.package version=latest_project_version module=view.kwargs.module klass=view.kwargs.klass %}">
+{% endblock %}
+
 
 {% block extra_js %}
     <script>

--- a/cbv/templates/cbv/module_detail.html
+++ b/cbv/templates/cbv/module_detail.html
@@ -5,7 +5,7 @@
 {% block title %}{{ object }}{% endblock %}
 
 {% block extraheaders %}
-    <link rel="canonical" href="{{ request.scheme }}://{{ request.get_host }}{% url 'module-detail' package=view.kwargs.package version=latest_project_version module=view.kwargs.module klass=view.kwargs.klass %}">
+    <link rel="canonical" href="{{ request.scheme }}://{{ request.get_host }}{{ object.get_latest_version_url }}">
 {% endblock %}
 
 {% block nav %}

--- a/cbv/templates/cbv/module_detail.html
+++ b/cbv/templates/cbv/module_detail.html
@@ -4,6 +4,9 @@
 
 {% block title %}{{ object }}{% endblock %}
 
+{% block extraheaders %}
+    <link rel="canonical" href="{{ request.scheme }}://{{ request.get_host }}{% url 'module-detail' package=view.kwargs.package version=latest_project_version module=view.kwargs.module klass=view.kwargs.klass %}">
+{% endblock %}
 
 {% block nav %}
     {% nav object.project_version object %}

--- a/cbv/views.py
+++ b/cbv/views.py
@@ -58,6 +58,12 @@ class KlassDetailView(FuzzySingleObjectMixin, DetailView):
             module__project_version__project__name__iexact=self.kwargs['package'],
         ).select_related('module__project_version__project').get()
 
+    def get_context_data(self, **kwargs):
+        context = super(KlassDetailView, self).get_context_data(**kwargs)
+        latest_project_version = ProjectVersion.objects.get_latest(kwargs.get('package')).version_number
+        context['latest_project_version'] = latest_project_version
+        return context
+
 
 class LatestKlassDetailView(FuzzySingleObjectMixin, DetailView):
     model = Klass
@@ -109,7 +115,10 @@ class ModuleDetailView(FuzzySingleObjectMixin, DetailView):
             'project_version': self.project_version,
             'klass_list': Klass.objects.filter(module=self.object).select_related('module__project_version', 'module__project_version__project')
         })
-        return super(ModuleDetailView, self).get_context_data(**kwargs)
+        context = super(ModuleDetailView, self).get_context_data(**kwargs)
+        latest_project_version = ProjectVersion.objects.get_latest(kwargs.get('package')).version_number
+        context['latest_project_version'] = latest_project_version
+        return context
 
 
 class VersionDetailView(ListView):

--- a/cbv/views.py
+++ b/cbv/views.py
@@ -58,12 +58,6 @@ class KlassDetailView(FuzzySingleObjectMixin, DetailView):
             module__project_version__project__name__iexact=self.kwargs['package'],
         ).select_related('module__project_version__project').get()
 
-    def get_context_data(self, **kwargs):
-        context = super(KlassDetailView, self).get_context_data(**kwargs)
-        latest_project_version = ProjectVersion.objects.get_latest(kwargs.get('package')).version_number
-        context['latest_project_version'] = latest_project_version
-        return context
-
 
 class LatestKlassDetailView(FuzzySingleObjectMixin, DetailView):
     model = Klass
@@ -115,10 +109,7 @@ class ModuleDetailView(FuzzySingleObjectMixin, DetailView):
             'project_version': self.project_version,
             'klass_list': Klass.objects.filter(module=self.object).select_related('module__project_version', 'module__project_version__project')
         })
-        context = super(ModuleDetailView, self).get_context_data(**kwargs)
-        latest_project_version = ProjectVersion.objects.get_latest(kwargs.get('package')).version_number
-        context['latest_project_version'] = latest_project_version
-        return context
+        return super(ModuleDetailView, self).get_context_data(**kwargs)
 
 
 class VersionDetailView(ListView):


### PR DESCRIPTION
Based on @YPCrumble's https://github.com/refreshoxford/django-cbv-inspector/pull/125 but extending to filter Django versions by the presence of the current module or klass.