### PR TITLE
Decorated methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ tests/test.zip
 /docs/_build
 *.sqlite
 *.db
+staticfiles

--- a/cbv/management/commands/populate_cbv.py
+++ b/cbv/management/commands/populate_cbv.py
@@ -262,6 +262,16 @@ class Command(BaseCommand):
 
         # METHOD
         elif inspect.ismethod(member) or inspect.isfunction(member):
+            decorated = False
+            if hasattr(member, 'func'):
+                member = member.func
+                decorated = True
+            if hasattr(member, 'im_func') and getattr(member.im_func, 'func_closure', None):
+                member = member.im_func
+                decorated = True
+            while getattr(member, 'func_closure', None):
+                member = member.func_closure[-1].cell_contents
+                decorated = True
             if not self.ok_to_add_method(member, parent):
                 return
             print('    def ' + member_name)

--- a/cbv/management/commands/populate_cbv.py
+++ b/cbv/management/commands/populate_cbv.py
@@ -263,6 +263,7 @@ class Command(BaseCommand):
         # METHOD
         elif inspect.ismethod(member) or inspect.isfunction(member):
             decorated = False
+            # py2 decoration
             if hasattr(member, 'func'):
                 member = member.func
                 decorated = True
@@ -272,6 +273,13 @@ class Command(BaseCommand):
             while getattr(member, 'func_closure', None):
                 member = member.func_closure[-1].cell_contents
                 decorated = True
+
+            # py3 decoration
+            while getattr(member, '__wrapped__', None):
+                member = member.__wrapped__
+                decorated = True
+
+            # Checks
             if not self.ok_to_add_method(member, parent):
                 return
             print('    def ' + member_name)


### PR DESCRIPTION
_Not to be merged yet: need to decide on which fixtures to regenerate and add them_

Made this work for Python 3.
Haven't tested it on Python 2 this time as I already rebased master in but I know from #123 that it was working so I've left this in there.

However, we've since stopped supporting Python 2 in other areas of the project (I haven't looked at how much or little work getting the populate script working would take)

I propose we can probably just update the fixtures for those Django versions which support Python 3 and ignore the oldest ones. Doing fixtures for the really old versions is getting increasingly difficult.