### PR TITLE
show permalink on keyboard focus

### DIFF
--- a/cbv/static/style.css
+++ b/cbv/static/style.css
@@ -93,6 +93,7 @@ code.attribute.overridden {
     font-size: 0.75em;
     transition: opacity 0.5s;
 }
+.method.accordion-group:focus-within .permalink,
 .method.accordion-group:hover .permalink {
     opacity: 1.0;
 }


### PR DESCRIPTION
Steps to reproduce the issue:

- focus on a method header
- press the tab key
- expected result: I can see that focus is on the permalink
- actual result: focus is on the permalink, but it is invisible